### PR TITLE
Update functions.php

### DIFF
--- a/html/functions.php
+++ b/html/functions.php
@@ -608,7 +608,7 @@
 		print '</table>';
 	}
 	
-	function getItemsFromDb($charid, $packname) {
+	function getItemsFromDb($charid, $packname = null) {
 		global $inGameColor;
 		$selectinfo = "accountLogin, accountRealm, charName, itemId, itemName, itemType, itemQuality, itemImage, itemDescription, itemMD5, itemLocation, itemColor";
 		
@@ -663,6 +663,7 @@
 					$filterBy	= "";
 					$filterBy2	= "";
 					$orderBy	= "";
+					$orderBy2	= "";
 					$colorF		= "";
 					
 					$limit		= "LIMIT " . (string)$packitems[$i]['occu'];


### PR DESCRIPTION
PHP 7.1.x or higher throws an error (instead of a warning) if a function is called with too few arguments.
Give the second argument a default value of null so as not to effect the logic any.

Also complained about orderBy2 being undefined, so give that a value as well.