### PR TITLE
Handle Account Registration in Entry Script

### DIFF
--- a/kolbot/D2BotDropper.dbj
+++ b/kolbot/D2BotDropper.dbj
@@ -938,6 +938,13 @@ MainSwitch:
 		locationTimeout(StarterConfig.GameDoesNotExistTimeout * 1e3, location);
 
 		break;
+	case 34: // Email registration
+		if (getControl(6, 415, 412, 128, 35)) {
+			ControlAction.click(6, 415, 412, 128, 35);
+		} else {
+			ControlAction.click(6, 265, 572, 272, 35);
+		}
+		break;
 	case 38: // Game is full
 		D2Bot.printToConsole("Game is full");
 		//ControlAction.click(6, 652, 469, 120, 20);


### PR DESCRIPTION
In theory this should have already been handled by AutoMule, but do the same thing it would have if we hit this case.

Just clicks on Do Not Register and Continue to get to the character selection screen.